### PR TITLE
add `timestamp` and `actor_id` arguments for data retrieval

### DIFF
--- a/app-libs/stf/src/best_energy_helpers.rs
+++ b/app-libs/stf/src/best_energy_helpers.rs
@@ -23,7 +23,7 @@ pub fn get_orders_index(
 	let index = orders
 		.iter()
 		.position(|o| o.actor_id == actor_id)
-		.ok_or(StfError::Dispatch(format!("Leaf Index {:?}. Error: {:?}", actor_id, e)))?;
+		.ok_or(StfError::Dispatch(format!("Leaf Index error: {:?}", actor_id)))?;
 
 	let orders_encoded: Vec<Vec<u8>> = orders.iter().map(|o| o.encode()).collect();
 

--- a/app-libs/stf/src/best_energy_helpers.rs
+++ b/app-libs/stf/src/best_energy_helpers.rs
@@ -16,7 +16,7 @@ pub fn get_merkle_proof_for_actor_from_file(
 	let orders = read_orders(timestamp)?;
 
 	get_merkle_proof_for_actor(actor_id, &orders)
-		.ok_or(StfError::Dispatch(format!("Leaf Index error: {:?}", actor_id)))
+		.ok_or_else(|| StfError::Dispatch(format!("Leaf Index error: {:?}", actor_id)))
 }
 
 pub fn read_orders(timestamp: &str) -> Result<Vec<Order>, StfError> {

--- a/app-libs/stf/src/best_energy_helpers.rs
+++ b/app-libs/stf/src/best_energy_helpers.rs
@@ -9,7 +9,10 @@ use std::{format, fs, vec::Vec};
 pub static ORDERS_DIR: &str = "./records/orders";
 pub static RESULTS_DIR: &str = "./records/market_results";
 
-pub fn get_orders_index(timestamp: &str, actor_id: &str) -> Result<(Vec<Vec<u8>>, usize), StfError> {
+pub fn get_orders_index(
+	timestamp: &str,
+	actor_id: &str,
+) -> Result<(Vec<Vec<u8>>, usize), StfError> {
 	let file = format!("{}/{}.json", ORDERS_DIR, timestamp);
 	let content = fs::read_to_string(file)
 		.map_err(|e| StfError::Dispatch(format!("Reading Orders File Error: {:?}", e)))?;
@@ -20,7 +23,7 @@ pub fn get_orders_index(timestamp: &str, actor_id: &str) -> Result<(Vec<Vec<u8>>
 	let index = orders
 		.iter()
 		.position(|o| o.actor_id == actor_id)
-		.ok_or(StfError::Dispatch(format!("Leaf Index Error: {:?}", actor_id)))?;
+		.ok_or(StfError::Dispatch(format!("Leaf Index {:?}. Error: {:?}", actor_id, e)))?;
 
 	let orders_encoded: Vec<Vec<u8>> = orders.iter().map(|o| o.encode()).collect();
 

--- a/app-libs/stf/src/best_energy_helpers.rs
+++ b/app-libs/stf/src/best_energy_helpers.rs
@@ -9,25 +9,24 @@ use std::{format, fs, vec::Vec};
 pub static ORDERS_DIR: &str = "./records/orders";
 pub static RESULTS_DIR: &str = "./records/market_results";
 
-pub fn get_orders_index(
+pub fn get_merkle_proof_for_actor_from_file(
 	timestamp: &str,
 	actor_id: &str,
-) -> Result<(Vec<Vec<u8>>, usize), StfError> {
+) -> Result<MerkleProofWithCodec<H256, Vec<u8>>, StfError> {
+	let orders = read_orders(timestamp)?;
+
+	get_merkle_proof_for_actor(actor_id, &orders)
+		.ok_or(StfError::Dispatch(format!("Leaf Index error: {:?}", actor_id)))
+}
+
+pub fn read_orders(timestamp: &str) -> Result<Vec<Order>, StfError> {
 	let file = format!("{}/{}.json", ORDERS_DIR, timestamp);
 	let content = fs::read_to_string(file)
 		.map_err(|e| StfError::Dispatch(format!("Reading Orders File Error: {:?}", e)))?;
-	let orders: Vec<Order> = serde_json::from_str(&content).map_err(|e| {
-		StfError::Dispatch(format!("Serializing Orders {:?}. Error: {:?}", content, e))
-	})?;
 
-	let index = orders
-		.iter()
-		.position(|o| o.actor_id == actor_id)
-		.ok_or(StfError::Dispatch(format!("Leaf Index error: {:?}", actor_id)))?;
-
-	let orders_encoded: Vec<Vec<u8>> = orders.iter().map(|o| o.encode()).collect();
-
-	Ok((orders_encoded, index))
+	serde_json::from_str(&content).map_err(|e| {
+		StfError::Dispatch(format!("Deserializing Orders {:?}. Error: {:?}", content, e))
+	})
 }
 
 pub fn write_orders(timestamp: &str, orders: &[Order]) -> Result<(), StfError> {

--- a/app-libs/stf/src/getter.rs
+++ b/app-libs/stf/src/getter.rs
@@ -11,19 +11,19 @@
 	limitations under the License.
 */
 
+use crate::{best_energy_helpers::get_orders, StfError};
 use binary_merkle_tree::{merkle_proof, MerkleProof};
 use codec::{Decode, Encode};
 use ita_sgx_runtime::System;
 #[cfg(feature = "evm")]
 use ita_sgx_runtime::{AddressMapping, HashedAddressMapping};
 use itp_stf_interface::ExecuteGetter;
-use itp_stf_primitives::types::{AccountId, KeyPair, LeafIndex, OrdersString, Signature};
+use itp_stf_primitives::types::{AccountId, ActorId, KeyPair, Signature, Timestamp};
 use itp_utils::stringify::account_id_to_string;
 use log::*;
 use serde::{Deserialize, Serialize};
-use simplyr_lib::Order;
 use sp_runtime::traits::{Keccak256, Verify};
-use std::{prelude::v1::*, time::Instant};
+use std::{format, io::Read, prelude::v1::*, time::Instant};
 
 #[cfg(feature = "evm")]
 use crate::evm_helpers::{get_evm_account, get_evm_account_codes, get_evm_account_storages};
@@ -109,7 +109,7 @@ pub enum TrustedGetter {
 	evm_account_codes(AccountId, H160),
 	#[cfg(feature = "evm")]
 	evm_account_storages(AccountId, H160, H256),
-	pay_as_bid_proof(AccountId, OrdersString, LeafIndex),
+	pay_as_bid_proof(AccountId, Timestamp, ActorId),
 }
 
 impl TrustedGetter {
@@ -124,8 +124,7 @@ impl TrustedGetter {
 			TrustedGetter::evm_account_codes(sender_account, _) => sender_account,
 			#[cfg(feature = "evm")]
 			TrustedGetter::evm_account_storages(sender_account, ..) => sender_account,
-			TrustedGetter::pay_as_bid_proof(sender_account, _orders_string, _leaf_index) =>
-				sender_account,
+			TrustedGetter::pay_as_bid_proof(sender_account, _timstamp, _actor_id) => sender_account,
 		}
 	}
 
@@ -207,38 +206,26 @@ impl ExecuteGetter for Getter {
 						None
 					},
 
-				TrustedGetter::pay_as_bid_proof(_who, orders_string, leaf_index) => {
+				TrustedGetter::pay_as_bid_proof(_who, timestamp, actor_id) => {
 					let now = Instant::now();
 
-					let orders: Vec<Order> =
-						serde_json::from_str(orders_string).expect("error serializing to JSON");
-					let orders_encoded: Vec<Vec<u8>> = orders.iter().map(|o| o.encode()).collect();
+					let orders = get_orders(timestamp, actor_id);
 
-					let leaf_index: usize = match (*leaf_index).try_into() {
-						Ok(index) => index,
-						Err(_) => {
-							info!("Error converting Leaf Index to usize: {})", leaf_index);
-							return None
+					match orders {
+						Ok((encoded_orders, index)) => {
+							println!("Index of {} is {}", actor_id, index);
+							println!("Records: {:?}", encoded_orders);
+
+							let proof: MerkleProofWithCodec<_, _> =
+								merkle_proof::<Keccak256, _, _>(encoded_orders, index).into();
+
+							let elapsed = now.elapsed();
+							info!("Time Elapsed for PayAsBid Proof is: {:.2?}", elapsed);
+
+							Some(proof.encode())
 						},
-					};
-
-					if leaf_index >= orders.len() {
-						info!(
-							"leaf_index out of range: {} (orders length: {})",
-							leaf_index,
-							orders.len()
-						);
-
-						return None
+						Err(e) => info!("Error: {:?}", e),
 					}
-
-					let proof: MerkleProofWithCodec<_, _> =
-						merkle_proof::<Keccak256, _, _>(orders_encoded, leaf_index).into();
-
-					let elapsed = now.elapsed();
-					info!("Time Elapsed for PayAsBid Proof is: {:.2?}", elapsed);
-
-					Some(proof.encode())
 				},
 			},
 			Getter::public(g) => match g {

--- a/app-libs/stf/src/getter.rs
+++ b/app-libs/stf/src/getter.rs
@@ -209,7 +209,7 @@ impl ExecuteGetter for Getter {
 				TrustedGetter::pay_as_bid_proof(_who, timestamp, actor_id) => {
 					let now = Instant::now();
 
-					let proof = match get_merkle_proof_for_actor_from_file(timestamp, &actor_id) {
+					let proof = match get_merkle_proof_for_actor_from_file(timestamp, actor_id) {
 						Ok(proof) => proof,
 						Err(e) => {
 							log::error!("Getting Orders and Index Error, {:?}", e);

--- a/app-libs/stf/src/getter.rs
+++ b/app-libs/stf/src/getter.rs
@@ -11,8 +11,8 @@
 	limitations under the License.
 */
 
-use crate::best_energy_helpers::get_orders_index;
-use binary_merkle_tree::{merkle_proof, MerkleProof};
+use crate::best_energy_helpers::get_merkle_proof_for_actor_from_file;
+use binary_merkle_tree::MerkleProof;
 use codec::{Decode, Encode};
 use ita_sgx_runtime::System;
 #[cfg(feature = "evm")]
@@ -22,7 +22,7 @@ use itp_stf_primitives::types::{AccountId, ActorId, KeyPair, Signature, Timestam
 use itp_utils::stringify::account_id_to_string;
 use log::*;
 use serde::{Deserialize, Serialize};
-use sp_runtime::traits::{Keccak256, Verify};
+use sp_runtime::traits::Verify;
 use std::{prelude::v1::*, time::Instant};
 
 #[cfg(feature = "evm")]
@@ -209,22 +209,18 @@ impl ExecuteGetter for Getter {
 				TrustedGetter::pay_as_bid_proof(_who, timestamp, actor_id) => {
 					let now = Instant::now();
 
-					// log the error and return none.
-					if let Ok((orders, index)) = get_orders_index(timestamp, &actor_id) {
-						let proof: MerkleProofWithCodec<_, _> =
-							merkle_proof::<Keccak256, _, _>(orders, index).into();
+					let proof = match get_merkle_proof_for_actor_from_file(timestamp, &actor_id) {
+						Ok(proof) => proof,
+						Err(e) => {
+							log::error!("Getting Orders and Index Error, {:?}", e);
+							return None
+						},
+					};
 
-						let elapsed = now.elapsed();
-						info!("Time Elapsed for PayAsBid Proof is: {:.2?}", elapsed);
+					let elapsed = now.elapsed();
+					info!("Time Elapsed for PayAsBid Proof is: {:.2?}", elapsed);
 
-						Some(proof.encode())
-					} else {
-						if let Err(e) = get_orders_index(timestamp, actor_id) {
-							log::error!("Getting Orders and Index Error: {:?}", e);
-						}
-
-						return None
-					}
+					Some(proof.encode())
 				},
 			},
 			Getter::public(g) => match g {

--- a/app-libs/stf/src/getter.rs
+++ b/app-libs/stf/src/getter.rs
@@ -11,7 +11,7 @@
 	limitations under the License.
 */
 
-use crate::{best_energy_helpers::get_orders_index, StfError};
+use crate::best_energy_helpers::get_orders_index;
 use binary_merkle_tree::{merkle_proof, MerkleProof};
 use codec::{Decode, Encode};
 use ita_sgx_runtime::System;
@@ -23,7 +23,7 @@ use itp_utils::stringify::account_id_to_string;
 use log::*;
 use serde::{Deserialize, Serialize};
 use sp_runtime::traits::{Keccak256, Verify};
-use std::{format, prelude::v1::*, time::Instant};
+use std::{prelude::v1::*, time::Instant};
 
 #[cfg(feature = "evm")]
 use crate::evm_helpers::{get_evm_account, get_evm_account_codes, get_evm_account_storages};
@@ -209,19 +209,22 @@ impl ExecuteGetter for Getter {
 				TrustedGetter::pay_as_bid_proof(_who, timestamp, actor_id) => {
 					let now = Instant::now();
 
-					let (orders, index) = get_orders_index(timestamp, &actor_id)
-						.map_err(|e| {
-							StfError::Dispatch(format!("Getting Orders and Index Error: {:?}", e))
-						})
-						.ok()?;
+					// log the error and return none.
+					if let Ok((orders, index)) = get_orders_index(timestamp, &actor_id) {
+						let proof: MerkleProofWithCodec<_, _> =
+							merkle_proof::<Keccak256, _, _>(orders, index).into();
 
-					let proof: MerkleProofWithCodec<_, _> =
-						merkle_proof::<Keccak256, _, _>(orders, index).into();
+						let elapsed = now.elapsed();
+						info!("Time Elapsed for PayAsBid Proof is: {:.2?}", elapsed);
 
-					let elapsed = now.elapsed();
-					info!("Time Elapsed for PayAsBid Proof is: {:.2?}", elapsed);
+						Some(proof.encode())
+					} else {
+						if let Err(e) = get_orders_index(timestamp, actor_id) {
+							log::error!("Getting Orders and Index Error: {:?}", e);
+						}
 
-					Some(proof.encode())
+						return None
+					}
 				},
 			},
 			Getter::public(g) => match g {

--- a/app-libs/stf/src/trusted_call.rs
+++ b/app-libs/stf/src/trusted_call.rs
@@ -50,7 +50,7 @@ use ita_sgx_runtime::{AddressMapping, HashedAddressMapping};
 #[cfg(feature = "evm")]
 use crate::evm_helpers::{create_code_hash, evm_create2_address, evm_create_address};
 
-use crate::best_energy_helpers::{write_orders, write_results, ORDERS_DIR};
+use crate::best_energy_helpers::{write_orders, write_results, ORDERS_DIR, RESULTS_DIR};
 
 #[derive(Encode, Decode, Clone, Debug, PartialEq, Eq)]
 #[allow(non_camel_case_types)]
@@ -281,9 +281,11 @@ where
 			TrustedCall::pay_as_bid(_who, orders_string) => {
 				let now = Instant::now();
 
-				fs::create_dir_all(ORDERS_DIR).map_err(|err| {
-					StfError::Dispatch(format!("Creating orders directory. Error: {:?}", err))
-				})?;
+				for dir in &[ORDERS_DIR, RESULTS_DIR] {
+					fs::create_dir_all(dir).map_err(|err| {
+						StfError::Dispatch(format!("Error creating directory {:?}: {:?}", dir, err))
+					})?;
+				}
 
 				let orders: Vec<Order> = serde_json::from_str(&orders_string).map_err(|err| {
 					StfError::Dispatch(format!("Error serializing to JSON: {}", err))

--- a/cli/demo_energy_market.sh
+++ b/cli/demo_energy_market.sh
@@ -60,6 +60,7 @@ WORKER1URL=${WORKER1URL:-"wss://127.0.0.1"}
 
 CLIENT_BIN=${CLIENT_BIN:-"./../bin/integritee-cli"}
 
+TIMESTAMP="2022-03-04T05:06:07+00:00"
 ORDERS_FILE=${ORDERS_FILE:-"../bin/orders/order_10_users.json"}
 FILE_CONTENTS=$(cat "$ORDERS_FILE" | tr -d '[:space:]')
 ORDERS_STRING="$FILE_CONTENTS"
@@ -75,7 +76,7 @@ CLIENT="${CLIENT_BIN} -p ${NPORT} -P ${WORKER1PORT} -u ${NODEURL} -U ${WORKER1UR
 read -r MRENCLAVE <<< "$($CLIENT list-workers | awk '/  MRENCLAVE: / { print $2; exit }')"
 
 echo "* Getting merkle proof for orders"
-PROOF=`$CLIENT trusted --mrenclave ${MRENCLAVE} --direct pay-as-bid-proof //Alice ${ORDERS_STRING} 1`
+PROOF=`$CLIENT trusted --mrenclave ${MRENCLAVE} --direct pay-as-bid-proof //Alice ${TIMESTAMP} actor_0`
 echo "Proof: ${PROOF}"
 
 echo "* Verifying merkle proof"

--- a/cli/src/trusted_base_cli/commands/pay_as_bid_proof.rs
+++ b/cli/src/trusted_base_cli/commands/pay_as_bid_proof.rs
@@ -28,8 +28,8 @@ use codec;
 pub struct PayAsBidProofCommand {
 	/// AccountId in ss58check format
 	account: String,
-	orders_string: String,
-	leaf_index: String,
+	timestamp: String,
+	actor_id: String,
 }
 
 impl PayAsBidProofCommand {
@@ -42,8 +42,8 @@ impl PayAsBidProofCommand {
 				cli,
 				trusted_args,
 				&self.account,
-				self.orders_string.clone(),
-				self.leaf_index.clone()
+				self.timestamp.clone(),
+				self.actor_id.clone()
 			))
 			.unwrap()
 		);
@@ -54,14 +54,14 @@ pub(crate) fn pay_as_bid_proof(
 	cli: &Cli,
 	trusted_args: &TrustedCli,
 	arg_who: &str,
-	orders_string: String,
-	leaf_index: String,
+	timestamp: String,
+	actor_id: String,
 ) -> MerkleProofWithCodec<H256, Vec<u8>> {
 	debug!("arg_who = {:?}", arg_who);
 	let who = get_pair_from_str(trusted_args, arg_who);
 
 	let top: TrustedOperation =
-		TrustedGetter::pay_as_bid_proof(who.public().into(), orders_string, leaf_index)
+		TrustedGetter::pay_as_bid_proof(who.public().into(), timestamp, actor_id)
 			.sign(&KeyPair::Sr25519(Box::new(who)))
 			.into();
 

--- a/cli/src/trusted_base_cli/commands/pay_as_bid_proof.rs
+++ b/cli/src/trusted_base_cli/commands/pay_as_bid_proof.rs
@@ -29,7 +29,7 @@ pub struct PayAsBidProofCommand {
 	/// AccountId in ss58check format
 	account: String,
 	orders_string: String,
-	leaf_index: u8,
+	leaf_index: String,
 }
 
 impl PayAsBidProofCommand {
@@ -43,7 +43,7 @@ impl PayAsBidProofCommand {
 				trusted_args,
 				&self.account,
 				self.orders_string.clone(),
-				self.leaf_index
+				self.leaf_index.clone()
 			))
 			.unwrap()
 		);
@@ -55,13 +55,13 @@ pub(crate) fn pay_as_bid_proof(
 	trusted_args: &TrustedCli,
 	arg_who: &str,
 	orders_string: String,
-	leaf_index: u8,
+	leaf_index: String,
 ) -> MerkleProofWithCodec<H256, Vec<u8>> {
 	debug!("arg_who = {:?}", arg_who);
 	let who = get_pair_from_str(trusted_args, arg_who);
 
 	let top: TrustedOperation =
-		TrustedGetter::pay_as_bid_proof(who.public().into(), orders_string, leaf_index.to_string())
+		TrustedGetter::pay_as_bid_proof(who.public().into(), orders_string, leaf_index)
 			.sign(&KeyPair::Sr25519(Box::new(who)))
 			.into();
 

--- a/cli/src/trusted_base_cli/commands/pay_as_bid_proof.rs
+++ b/cli/src/trusted_base_cli/commands/pay_as_bid_proof.rs
@@ -61,7 +61,7 @@ pub(crate) fn pay_as_bid_proof(
 	let who = get_pair_from_str(trusted_args, arg_who);
 
 	let top: TrustedOperation =
-		TrustedGetter::pay_as_bid_proof(who.public().into(), orders_string, leaf_index)
+		TrustedGetter::pay_as_bid_proof(who.public().into(), orders_string, leaf_index.to_string())
 			.sign(&KeyPair::Sr25519(Box::new(who)))
 			.into();
 

--- a/core-primitives/stf-primitives/src/types.rs
+++ b/core-primitives/stf-primitives/src/types.rs
@@ -26,10 +26,11 @@ pub type AccountId = AccountId32;
 pub type Hash = H256;
 pub type BalanceTransferFn = ([u8; 2], AccountId, Compact<u128>);
 pub type ShardIdentifier = H256;
+pub type Timestamp = String;
 pub type OrdersString = String;
 pub type GridFeeMatrixFile = String;
 
-pub type LeafIndex = u8;
+pub type ActorId = String;
 
 #[derive(Clone)]
 pub enum KeyPair {


### PR DESCRIPTION
This PR aims to enhance the functionality of `pay-as-bid-proof` function by replacing `order_file` and `leaf_index` with `timestamp` and `actor_id`. With the `timestamp` argument, the function will be able to retrieve `orders` for the given `timestamp` value. On the other hand, the `actor_id` argument will enable the function to retrieve the `leaf_index` for the given `actor_id`.

## Related Issues
Closes #21 