### PR TITLE
implement a getter function for market results

### DIFF
--- a/app-libs/stf/src/best_energy_helpers.rs
+++ b/app-libs/stf/src/best_energy_helpers.rs
@@ -22,10 +22,10 @@ pub fn get_merkle_proof_for_actor_from_file(
 pub fn read_market_results(timestamp: &str) -> Result<MarketOutput, StfError> {
 	let file = format!("{}/{}.json", RESULTS_DIR, timestamp);
 	let content = fs::read_to_string(file)
-		.map_err(|e| StfError::Dispatch(format!("Reading Orders File Error: {:?}", e)))?;
+		.map_err(|e| StfError::Dispatch(format!("Reading Results File Error: {:?}", e)))?;
 
 	serde_json::from_str(&content).map_err(|e| {
-		StfError::Dispatch(format!("Deserializing Orders {:?}. Error: {:?}", content, e))
+		StfError::Dispatch(format!("Deserializing Results {:?}. Error: {:?}", content, e))
 	})
 }
 

--- a/app-libs/stf/src/best_energy_helpers.rs
+++ b/app-libs/stf/src/best_energy_helpers.rs
@@ -19,6 +19,16 @@ pub fn get_merkle_proof_for_actor_from_file(
 		.ok_or_else(|| StfError::Dispatch(format!("Leaf Index error: {:?}", actor_id)))
 }
 
+pub fn read_market_results(timestamp: &str) -> Result<MarketOutput, StfError> {
+	let file = format!("{}/{}.json", RESULTS_DIR, timestamp);
+	let content = fs::read_to_string(file)
+		.map_err(|e| StfError::Dispatch(format!("Reading Orders File Error: {:?}", e)))?;
+
+	serde_json::from_str(&content).map_err(|e| {
+		StfError::Dispatch(format!("Deserializing Orders {:?}. Error: {:?}", content, e))
+	})
+}
+
 pub fn read_orders(timestamp: &str) -> Result<Vec<Order>, StfError> {
 	let file = format!("{}/{}.json", ORDERS_DIR, timestamp);
 	let content = fs::read_to_string(file)

--- a/cli/src/trusted_base_cli/commands/get_market_results.rs
+++ b/cli/src/trusted_base_cli/commands/get_market_results.rs
@@ -16,13 +16,12 @@ use crate::{
 	trusted_operation::perform_trusted_operation, Cli,
 };
 
+use codec::Decode;
 use ita_stf::{TrustedGetter, TrustedOperation};
 use itp_stf_primitives::types::KeyPair;
 use log::debug;
 use simplyr_lib::MarketOutput;
 use sp_core::Pair;
-
-use codec;
 
 #[derive(Parser)]
 pub struct GetMarketResultsCommand {
@@ -64,9 +63,9 @@ pub(crate) fn get_market_results(
 	let res = perform_trusted_operation(cli, trusted_args, &top);
 
 	match res {
-		Some(market_results) => {
-			let rus: MarketOutput = MarketOutput { matches: market_results };
-			rus
+		Some(market_results) => match MarketOutput::decode(&mut market_results.as_slice()) {
+			Ok(market_output) => market_output,
+			Err(err) => panic!("Error deserializing market results: {}", err),
 		},
 		None => {
 			panic!("Results not found");

--- a/cli/src/trusted_base_cli/commands/get_market_results.rs
+++ b/cli/src/trusted_base_cli/commands/get_market_results.rs
@@ -1,0 +1,75 @@
+/*
+	Copyright 2021 Integritee AG and Supercomputing Systems AG
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+		http://www.apache.org/licenses/LICENSE-2.0
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+use crate::{
+	trusted_cli::TrustedCli, trusted_command_utils::get_pair_from_str,
+	trusted_operation::perform_trusted_operation, Cli,
+};
+
+use ita_stf::{TrustedGetter, TrustedOperation};
+use itp_stf_primitives::types::KeyPair;
+use log::debug;
+use simplyr_lib::MarketOutput;
+use sp_core::Pair;
+
+use codec;
+
+#[derive(Parser)]
+pub struct GetMarketResultsCommand {
+	/// AccountId in ss58check format
+	account: String,
+	timestamp: String,
+}
+
+impl GetMarketResultsCommand {
+	pub(crate) fn run(&self, cli: &Cli, trusted_args: &TrustedCli) {
+		println!(
+			"{:?}",
+			// if we serialize with serde-json we can easily just pass it as
+			// an argument in the verify-proof command.
+			serde_json::to_string(&get_market_results(
+				cli,
+				trusted_args,
+				&self.account,
+				self.timestamp.clone(),
+			))
+			.unwrap()
+		);
+	}
+}
+
+pub(crate) fn get_market_results(
+	cli: &Cli,
+	trusted_args: &TrustedCli,
+	arg_who: &str,
+	timestamp: String,
+) -> MarketOutput {
+	debug!("arg_who = {:?}", arg_who);
+	let who = get_pair_from_str(trusted_args, arg_who);
+
+	let top: TrustedOperation = TrustedGetter::get_market_results(who.public().into(), timestamp)
+		.sign(&KeyPair::Sr25519(Box::new(who)))
+		.into();
+
+	let res = perform_trusted_operation(cli, trusted_args, &top);
+
+	match res {
+		Some(market_results) => {
+			let rus: MarketOutput = MarketOutput { matches: market_results };
+			rus
+		},
+		None => {
+			panic!("Results not found");
+		},
+	}
+}

--- a/cli/src/trusted_base_cli/commands/mod.rs
+++ b/cli/src/trusted_base_cli/commands/mod.rs
@@ -6,3 +6,4 @@ pub mod set_balance;
 pub mod transfer;
 pub mod unshield_funds;
 pub mod verify_proof;
+pub mod get_market_results;

--- a/cli/src/trusted_base_cli/commands/mod.rs
+++ b/cli/src/trusted_base_cli/commands/mod.rs
@@ -1,4 +1,5 @@
 pub mod balance;
+pub mod get_market_results;
 pub mod nonce;
 pub mod pay_as_bid;
 pub mod pay_as_bid_proof;
@@ -6,4 +7,3 @@ pub mod set_balance;
 pub mod transfer;
 pub mod unshield_funds;
 pub mod verify_proof;
-pub mod get_market_results;

--- a/cli/src/trusted_base_cli/mod.rs
+++ b/cli/src/trusted_base_cli/mod.rs
@@ -13,10 +13,10 @@
 
 use crate::{
 	trusted_base_cli::commands::{
-		balance::BalanceCommand, nonce::NonceCommand, pay_as_bid::PayAsBidCommand,
-		pay_as_bid_proof::PayAsBidProofCommand, set_balance::SetBalanceCommand,
-		transfer::TransferCommand, unshield_funds::UnshieldFundsCommand,
-		verify_proof::VerifyMerkleProofCommand,
+		balance::BalanceCommand, get_market_results::GetMarketResultsCommand, nonce::NonceCommand,
+		pay_as_bid::PayAsBidCommand, pay_as_bid_proof::PayAsBidProofCommand,
+		set_balance::SetBalanceCommand, transfer::TransferCommand,
+		unshield_funds::UnshieldFundsCommand, verify_proof::VerifyMerkleProofCommand,
 	},
 	trusted_cli::TrustedCli,
 	trusted_command_utils::get_keystore_path,
@@ -60,6 +60,9 @@ pub enum TrustedBaseCommand {
 
 	/// VerifyProof Command
 	VerifyProof(VerifyMerkleProofCommand),
+
+	/// Get Market Results Command
+	MarketResults(GetMarketResultsCommand)
 }
 
 impl TrustedBaseCommand {
@@ -75,6 +78,7 @@ impl TrustedBaseCommand {
 			TrustedBaseCommand::PayAsBid(cmd) => cmd.run(cli, trusted_cli),
 			TrustedBaseCommand::PayAsBidProof(cmd) => cmd.run(cli, trusted_cli),
 			TrustedBaseCommand::VerifyProof(cmd) => cmd.run(cli, trusted_cli),
+			TrustedBaseCommand::MarketResults(cmd) => cmd.run(cli, trusted_cli),
 		}
 	}
 }

--- a/cli/src/trusted_base_cli/mod.rs
+++ b/cli/src/trusted_base_cli/mod.rs
@@ -62,7 +62,7 @@ pub enum TrustedBaseCommand {
 	VerifyProof(VerifyMerkleProofCommand),
 
 	/// Get Market Results Command
-	MarketResults(GetMarketResultsCommand)
+	GetMarketResults(GetMarketResultsCommand),
 }
 
 impl TrustedBaseCommand {
@@ -78,7 +78,7 @@ impl TrustedBaseCommand {
 			TrustedBaseCommand::PayAsBid(cmd) => cmd.run(cli, trusted_cli),
 			TrustedBaseCommand::PayAsBidProof(cmd) => cmd.run(cli, trusted_cli),
 			TrustedBaseCommand::VerifyProof(cmd) => cmd.run(cli, trusted_cli),
-			TrustedBaseCommand::MarketResults(cmd) => cmd.run(cli, trusted_cli),
+			TrustedBaseCommand::GetMarketResults(cmd) => cmd.run(cli, trusted_cli),
 		}
 	}
 }


### PR DESCRIPTION
This PR contains changes that implement a getter function for retrieving `market_results` based on a given `timestamp`.

## Related Issues
Closes #19 