### PR TITLE
My/fix python client

### DIFF
--- a/cli/src/trusted_base_cli/commands/get_market_results.rs
+++ b/cli/src/trusted_base_cli/commands/get_market_results.rs
@@ -26,8 +26,8 @@ use sp_core::Pair;
 #[derive(Parser)]
 pub struct GetMarketResultsCommand {
 	/// AccountId in ss58check format
-	account: String,
-	timestamp: String,
+	pub account: String,
+	pub timestamp: String,
 }
 
 impl GetMarketResultsCommand {

--- a/cli/src/trusted_base_cli/commands/verify_proof.rs
+++ b/cli/src/trusted_base_cli/commands/verify_proof.rs
@@ -24,7 +24,7 @@ use sp_runtime::traits::Keccak256;
 
 #[derive(Parser)]
 pub struct VerifyMerkleProofCommand {
-	merkle_proof_json: String,
+	pub merkle_proof_json: String,
 }
 
 impl VerifyMerkleProofCommand {

--- a/cli/src/trusted_operation.rs
+++ b/cli/src/trusted_operation.rs
@@ -373,7 +373,7 @@ pub(crate) fn wait_until(
 }
 
 fn connection_can_be_closed(top_status: TrustedOperationStatus) -> bool {
-	!matches!(
+	matches!(
 		top_status,
 		TrustedOperationStatus::Submitted
 			| TrustedOperationStatus::Future


### PR DESCRIPTION
This PR will define vars as public to call the Rust-CLI from Python client.
Also, it will fix the terminal hang issue after executing the `pay_as_bid` command. 